### PR TITLE
Changed colorbar and ghost to be a percentage

### DIFF
--- a/jstarbox.js
+++ b/jstarbox.js
@@ -50,9 +50,9 @@
 			var size = arguments[1] || data.positioner.width();
 			var include_ghost = arguments[2];
 			if(include_ghost) {
-				data.ghost.css({width: ""+(val*size)+"px"});
+				data.ghost.css({width: ""+(val*100)+"%"});
 			}
-			data.colorbar.css({width: ""+(val*size)+"px"});
+			data.colorbar.css({width: ""+(val*100)+"%"});
 			data.opts.currentValue = val;
 		},
 		


### PR DESCRIPTION
I was having an issue using your plugin and backbone. The problem was that the way views are rendered and appended to the page, there would be no initial size for data.positioner. Changing the math to work of width percentages was all that was needed.
